### PR TITLE
docs: project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# docs.dent.dev
+
+This repository contains documentation for the DENT Project, including instructions, guides, and references.
+
+To access documentation related to the DENT Project, visit [DENT Docs](https://docs.dent.dev/).
+
+## Overview
+
+[dentOS](https://github.com/dentproject/dentOS) is a SwitchDev based NOS built on top of Open Network Linux.
+
+Find out more about DENT at [DENT Project Website](https://www.dent.dev).
+
+Find out more about ONL at [Open Network Linux Website](http://opennetlinux.org).
+
+## Software License
+
+Licenses for the software are described under the [LICENSE](LICENSE) file. Download or use of the software implies consent.


### PR DESCRIPTION
Adds a README, considering the main dentos repo in mind. 

Not sure why the existing README was deleted here- https://github.com/dentproject/docs.dent.dev/pull/6/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5