### PR TITLE
Sub-Directories included for Platform and Network Configuration

### DIFF
--- a/NetworkConfiguration.md
+++ b/NetworkConfiguration.md
@@ -7,4 +7,45 @@ layout: default
 
 # Network Configuration
 
-(Todo)
+**DENT offers a wide range of Network Configuration options. These include the following:**
+
+### Link Aggregation and Load Balancing
+
+- LAG/LACP (Link Aggregation Group/Link Aggregation Control Protocol)
+
+- L2/L3 ECMP (Equal-Cost Multipath)
+
+### Network Addressing and Filtering
+
+- DHCP (Dynamic Host Configuration Protocol)
+- ACL (TC-Flower)
+- NAT (Network Address Translation)
+
+### VLAN Configuration
+
+- Bridging Layer 2
+- VLANs (Configuring 802.1q Interfaces)
+- VLAN Routing on 802.1q Interfaces
+- PT (Port Translation)
+
+### Traffic Control and Policing
+
+- Egress Policer
+- Control Plane Policer
+- Dataplane policing (BUM traffic Policing/Data packet policing/Control packet policing)
+
+### Network Discovery and Management
+
+- LLDP (Link Layer Discovery Protocol)
+- VRRP (Virtual Router Redundancy Protocol) – keepaliveD
+- STP (Spanning Tree Protocol)
+
+### Routing and Forwarding
+
+- IPv4 Support
+- IPv6 Support
+- Dynamic Routing (BGP and OSPF)
+- Static Routing
+- IGMP Snooping
+
+**To learn more about these groups view the table of contents below:**

--- a/NetworkConfigurations/LinkAggregationAndLoadBalancing.md
+++ b/NetworkConfigurations/LinkAggregationAndLoadBalancing.md
@@ -1,0 +1,11 @@
+---
+title: Link Aggregation and Load Balancing
+parent: Network Configuration
+nav_order: 1
+has_children: true
+layout: default
+---
+
+# Link Aggregation and Load Balancing
+
+Possible Link Aggregation and Load Balancing Configurations include:

--- a/NetworkConfigurations/NetworkAddressingAndFiltering.md
+++ b/NetworkConfigurations/NetworkAddressingAndFiltering.md
@@ -1,0 +1,11 @@
+---
+title: Network Addressing and Filtering
+parent: Network Configuration
+nav_order: 2
+has_children: true
+layout: default
+---
+
+# Network Addressing and Filtering
+
+Possible Network Addressing and Filtering Configurations include:

--- a/NetworkConfigurations/NetworkDiscoveryAndManagement.md
+++ b/NetworkConfigurations/NetworkDiscoveryAndManagement.md
@@ -1,0 +1,11 @@
+---
+title: Network Discovery and Management
+parent: Network Configuration
+nav_order: 5
+has_children: true
+layout: default
+---
+
+# Network Discovery and Management
+
+Possible Network Discovery and Management Configurations include:

--- a/NetworkConfigurations/RoutingAndForwarding.md
+++ b/NetworkConfigurations/RoutingAndForwarding.md
@@ -1,0 +1,11 @@
+---
+title: Routing and Forwarding
+parent: Network Configuration
+nav_order: 6
+has_children: true
+layout: default
+---
+
+# Routing and Forwarding
+
+Possible Routing and Forwarding Configurations include:

--- a/NetworkConfigurations/TrafficControlAndPolicing.md
+++ b/NetworkConfigurations/TrafficControlAndPolicing.md
@@ -1,0 +1,11 @@
+---
+title: Traffic Control and Policing
+parent: Network Configuration
+nav_order: 4
+has_children: true
+layout: default
+---
+
+# Traffic Control and Policing
+
+Possible Traffic Control and Policing Configurations include:

--- a/NetworkConfigurations/VLANConfiguraiton.md
+++ b/NetworkConfigurations/VLANConfiguraiton.md
@@ -1,0 +1,11 @@
+---
+title: VLAN Configuration
+parent: Network Configuration
+nav_order: 3
+has_children: true
+layout: default
+---
+
+# VLAN Configuration
+
+Possible VLAN Configurations include:

--- a/PlatformConfiguraiton.md
+++ b/PlatformConfiguraiton.md
@@ -7,4 +7,12 @@ layout: default
 
 # Platform Configuraiton
 
-(TODO)
+**DENT offers a wide range of Platform Configuration options. These include the following:**
+
+- Port Isolation
+
+- TC Persistence (Petunia)
+
+- IEEE 802.1x Port Based Authentication
+
+- Power over Ethernet (PoE) Management


### PR DESCRIPTION
This commit includes all the sub-directories that will hold the markdown files in the Platform and Network Configuration tabs. 

The list of subjects (mark down pages) are based on the DENT latest road map features found under the DENT OS website. https://dent.dev/ecosystem/roadmap/

Here is a document reviewed by Shridhar and Royal organizing the categories along with their Progress and Completion standing:
https://docs.google.com/spreadsheets/d/10GB45W8j1nqVSedgTCa_-vIXTrPqE6u8YR6niIO3cJg/edit?usp=sharing

The Categories and Subcategories act as directories while the listed features will be the actual content within those directories (markdown files for each). I made the subcategories to organize the topics into groups to help users when looking for information.

Currently no sub-categories were established for Platform Configuration due to the limited number. But may be subject to changes upon review.