### PR TITLE
fix: Duplicacy- Table of Contents

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -7,6 +7,4 @@ layout: default
 
 # Installation
 
-We'll be using [GNS3](https://www.gns3.com/) to install DENT.
-
-This installation guide offers detailed, step-by-step instructions for setting up the DENT Network Operating System within GNS3. Whether you're deploying it on a remote server, a virtual machine, or your local machine, this guide will walk you through the installation process.
+Welcome to the DENT NOS installation guide. This section provides an overview of how to install DENT NOS on your hardware. Additionally, it discusses an optional method to use DENT NOS through a Virtual Machine (VM) on GNS3.

--- a/NetworkConfiguration.md
+++ b/NetworkConfiguration.md
@@ -7,44 +7,4 @@ layout: default
 
 # Network Configuration
 
-**DENT offers a wide range of Network Configuration options. These include the following:**
-
-### Link Aggregation and Load Balancing
-
-- LAG/LACP (Link Aggregation Group/Link Aggregation Control Protocol)
-- L2/L3 ECMP (Equal-Cost Multipath)
-
-### Network Addressing and Filtering
-
-- DHCP (Dynamic Host Configuration Protocol)
-- ACL (TC-Flower)
-- NAT (Network Address Translation)
-
-### VLAN Configuration
-
-- Bridging Layer 2
-- VLANs (Configuring 802.1q Interfaces)
-- VLAN Routing on 802.1q Interfaces
-- PT (Port Translation)
-
-### Traffic Control and Policing
-
-- Egress Policer
-- Control Plane Policer
-- Dataplane policing (BUM traffic Policing/Data packet policing/Control packet policing)
-
-### Network Discovery and Management
-
-- LLDP (Link Layer Discovery Protocol)
-- VRRP (Virtual Router Redundancy Protocol) – keepaliveD
-- STP (Spanning Tree Protocol)
-
-### Routing and Forwarding
-
-- IPv4 Support
-- IPv6 Support
-- Dynamic Routing (BGP and OSPF)
-- Static Routing
-- IGMP Snooping
-
-**To learn more about these groups view the table of contents below:**
+DENT offers a wide range of network configuration options to meet diverse networking requirements. This section provides an overview of these options and their capabilities.

--- a/PlatformConfiguration.md
+++ b/PlatformConfiguration.md
@@ -7,9 +7,4 @@ layout: default
 
 # Platform Configuration
 
-**DENT offers a wide range of Platform Configuration options. These include the following:**
-
-- Port Isolation
-- TC Persistence (Petunia)
-- IEEE 802.1x Port Based Authentication
-- Power over Ethernet (PoE) Management
+DENT offers a wide range of platform configuration options to cater to various networking needs. This section provides an overview of the available configurations and their functionalities.


### PR DESCRIPTION
In the last meeting, we discussed keeping the grand_parent page short and specific (just like BISDNs) since the same content is already listed in the Table of Contents section. As a result, it was proposed to remove duplicate content and refine the content listed on the grand_parent pages of the docs.